### PR TITLE
fix SPIFFS_read length when reading beyond file size

### DIFF
--- a/src/spiffs_hydrogen.c
+++ b/src/spiffs_hydrogen.c
@@ -241,6 +241,7 @@ s32_t SPIFFS_read(spiffs *fs, spiffs_file fh, void *buf, s32_t len) {
       return avail;
     } else {
       SPIFFS_API_CHECK_RES_UNLOCK(fs, res);
+      len = avail;
     }
   } else {
     // reading within file size


### PR DESCRIPTION
when reading beyond file size, and when spiffs_object_read return SPIFFS_OK,
the length add to offset should be "avail" instead of len.
please review.