### PR TITLE
fix warning when spiffs_obj_id is 32 bit

### DIFF
--- a/src/spiffs_nucleus.h
+++ b/src/spiffs_nucleus.h
@@ -124,7 +124,7 @@
 #define SPIFFS_EV_IX_NEW                1
 #define SPIFFS_EV_IX_DEL                2
 
-#define SPIFFS_OBJ_ID_IX_FLAG           (1<<(8*sizeof(spiffs_obj_id)-1))
+#define SPIFFS_OBJ_ID_IX_FLAG           ((spiffs_obj_id)(1<<(8*sizeof(spiffs_obj_id)-1)))
 
 #define SPIFFS_UNDEFINED_LEN            (u32_t)(-1)
 


### PR DESCRIPTION
`SPIFFS_OBJ_ID_IX_FLAG` should be the same type as spiffs_obj_id, otherwise it defaults to (signed) int and causes a warning

```
/home/benpicco/dev/volaWare/module/spiffs/spiffs_nucleus.c: In function 'spiffs_erase_block':
/home/benpicco/dev/volaWare/module/spiffs/spiffs_nucleus.c:252:27: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
   if (fs->max_erase_count == SPIFFS_OBJ_ID_IX_FLAG) {
```