### PR TITLE
lseek should return the resulting offset

### DIFF
--- a/src/spiffs_hydrogen.c
+++ b/src/spiffs_hydrogen.c
@@ -488,7 +488,7 @@ s32_t SPIFFS_lseek(spiffs *fs, spiffs_file fh, s32_t offs, int whence) {
 
   SPIFFS_UNLOCK(fs);
 
-  return 0;
+  return offs;
 }
 
 s32_t SPIFFS_remove(spiffs *fs, char *path) {


### PR DESCRIPTION
According to posix, lseek returns the resulting offset.