### PR TITLE
align cand_scores

### DIFF
--- a/src/spiffs_gc.c
+++ b/src/spiffs_gc.c
@@ -249,9 +249,14 @@ s32_t spiffs_gc_find_candidate(
   memset(fs->work, 0xff, SPIFFS_CFG_LOG_PAGE_SZ(fs));
 
   // divide up work area into block indices and scores
-  // todo alignment?
   spiffs_block_ix *cand_blocks = (spiffs_block_ix *)fs->work;
   s32_t *cand_scores = (s32_t *)(fs->work + max_candidates * sizeof(spiffs_block_ix));
+
+   // align cand_scores on s32_t boundary
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpointer-to-int-cast"
+  cand_scores = (s32_t*)(((u32_t)cand_scores + sizeof(s32_t) - 1) & ~(sizeof(s32_t) - 1));
+#pragma GCC diagnostic pop
 
   *block_candidates = cand_blocks;
 


### PR DESCRIPTION
align cand_scores to prevent data aborts on architectures with alignment
restrictions