### PR TITLE
Fix pointer truncation on 64-bit platforms

### DIFF
--- a/src/spiffs_gc.c
+++ b/src/spiffs_gc.c
@@ -255,7 +255,7 @@ s32_t spiffs_gc_find_candidate(
    // align cand_scores on s32_t boundary
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpointer-to-int-cast"
-  cand_scores = (s32_t*)(((u32_t)cand_scores + sizeof(s32_t) - 1) & ~(sizeof(s32_t) - 1));
+  cand_scores = (s32_t*)(((ptrdiff_t)cand_scores + sizeof(ptrdiff_t) - 1) & ~(sizeof(ptrdiff_t) - 1));
 #pragma GCC diagnostic pop
 
   *block_candidates = cand_blocks;


### PR DESCRIPTION
Casting 64-bit `cand_scores` pointer to u32_t discards MSBs which causes segfault later in the code. Use ptrdiff_t type instead.

Without this change, test suite segfaults in `write_big_files_chunks_1` on 64-bit OSX 10.10.
With this change, test suite passes.