### PR TITLE
Removed unnecessary parameter in debug printout

### DIFF
--- a/src/spiffs_gc.c
+++ b/src/spiffs_gc.c
@@ -36,7 +36,7 @@ s32_t spiffs_gc_quick(
   int cur_entry = 0;
   spiffs_obj_id *obj_lu_buf = (spiffs_obj_id *)fs->lu_work;
 
-  SPIFFS_GC_DBG("gc_quick: running\n", cur_block);
+  SPIFFS_GC_DBG("gc_quick: running\n");
 #if SPIFFS_GC_STATS
   fs->stats_gc_runs++;
 #endif


### PR DESCRIPTION
This caused a compilation error with strictest setting on an embedded compiler