### PR TITLE
add tell and eof functions

### DIFF
--- a/src/spiffs.h
+++ b/src/spiffs.h
@@ -550,6 +550,20 @@ s32_t SPIFFS_gc_quick(spiffs *fs, u16_t max_free_pages);
  */
 s32_t SPIFFS_gc(spiffs *fs, u32_t size);
 
+/**
+ * Check if EOF reached.
+ * @param fs            the file system struct
+ * @param fh            the filehandle of the file to check
+ */
+s32_t SPIFFS_eof(spiffs *fs, spiffs_file fh);
+
+/**
+ * Get position in file.
+ * @param fs            the file system struct
+ * @param fh            the filehandle of the file to check
+ */
+s32_t SPIFFS_tell(spiffs *fs, spiffs_file fh);
+
 #if SPIFFS_TEST_VISUALISATION
 /**
  * Prints out a visualization of the filesystem.

--- a/src/spiffs_hydrogen.c
+++ b/src/spiffs_hydrogen.c
@@ -923,17 +923,20 @@ s32_t SPIFFS_gc(spiffs *fs, u32_t size) {
 }
 
 s32_t SPIFFS_eof(spiffs *fs, spiffs_file fh) {
+  s32_t res;
   SPIFFS_API_CHECK_CFG(fs);
   SPIFFS_API_CHECK_MOUNT(fs);
   SPIFFS_LOCK(fs);
 
+  fh = SPIFFS_FH_UNOFFS(fs, fh);
+
   spiffs_fd *fd;
-  s32_t res;
   res = spiffs_fd_get(fs, fh, &fd);
-  SPIFFS_API_CHECK_RES(fs, res);
+  SPIFFS_API_CHECK_RES_UNLOCK(fs, res);
 
 #if SPIFFS_CACHE_WR
-  spiffs_fflush_cache(fs, fh);
+  res = spiffs_fflush_cache(fs, fh);
+  SPIFFS_API_CHECK_RES_UNLOCK(fs, res);
 #endif
 
   res = (fd->fdoffset == fd->size);
@@ -943,17 +946,20 @@ s32_t SPIFFS_eof(spiffs *fs, spiffs_file fh) {
 }
 
 s32_t SPIFFS_tell(spiffs *fs, spiffs_file fh) {
+  s32_t res;
   SPIFFS_API_CHECK_CFG(fs);
   SPIFFS_API_CHECK_MOUNT(fs);
   SPIFFS_LOCK(fs);
 
+  fh = SPIFFS_FH_UNOFFS(fs, fh);
+
   spiffs_fd *fd;
-  s32_t res;
   res = spiffs_fd_get(fs, fh, &fd);
-  SPIFFS_API_CHECK_RES(fs, res);
+  SPIFFS_API_CHECK_RES_UNLOCK(fs, res);
 
 #if SPIFFS_CACHE_WR
-  spiffs_fflush_cache(fs, fh);
+  res = spiffs_fflush_cache(fs, fh);
+  SPIFFS_API_CHECK_RES_UNLOCK(fs, res);
 #endif
 
   res = fd->fdoffset;

--- a/src/spiffs_hydrogen.c
+++ b/src/spiffs_hydrogen.c
@@ -922,6 +922,46 @@ s32_t SPIFFS_gc(spiffs *fs, u32_t size) {
   return 0;
 }
 
+s32_t SPIFFS_eof(spiffs *fs, spiffs_file fh) {
+  SPIFFS_API_CHECK_CFG(fs);
+  SPIFFS_API_CHECK_MOUNT(fs);
+  SPIFFS_LOCK(fs);
+
+  spiffs_fd *fd;
+  s32_t res;
+  res = spiffs_fd_get(fs, fh, &fd);
+  SPIFFS_API_CHECK_RES(fs, res);
+
+#if SPIFFS_CACHE_WR
+  spiffs_fflush_cache(fs, fh);
+#endif
+
+  res = (fd->fdoffset == fd->size);
+
+  SPIFFS_UNLOCK(fs);
+  return res;
+}
+
+s32_t SPIFFS_tell(spiffs *fs, spiffs_file fh) {
+  SPIFFS_API_CHECK_CFG(fs);
+  SPIFFS_API_CHECK_MOUNT(fs);
+  SPIFFS_LOCK(fs);
+
+  spiffs_fd *fd;
+  s32_t res;
+  res = spiffs_fd_get(fs, fh, &fd);
+  SPIFFS_API_CHECK_RES(fs, res);
+
+#if SPIFFS_CACHE_WR
+  spiffs_fflush_cache(fs, fh);
+#endif
+
+  res = fd->fdoffset;
+
+  SPIFFS_UNLOCK(fs);
+  return res;
+}
+
 
 #if SPIFFS_TEST_VISUALISATION
 s32_t SPIFFS_vis(spiffs *fs) {


### PR DESCRIPTION
When upgrading sming to use the latest version of spiffs I found these functions in the old code. I don't know where they originate from but we use them and they might be handy for others too.