### PR TITLE
Magic2 implementation

### DIFF
--- a/src/spiffs_nucleus.h
+++ b/src/spiffs_nucleus.h
@@ -132,6 +132,8 @@
 #define SPIFFS_OBJ_ID_FREE              ((spiffs_obj_id)-1)
 
 #define SPIFFS_MAGIC(fs)                ((spiffs_obj_id)(0x20140529 ^ SPIFFS_CFG_LOG_PAGE_SZ(fs)))
+#define SPIFFS_MAGIC_START(fs)			((spiffs_obj_id)(0x20140527 ^ SPIFFS_CFG_LOG_PAGE_SZ(fs)))
+#define SPIFFS_MAGIC_END(fs)			((spiffs_obj_id)(0x20140528 ^ SPIFFS_CFG_LOG_PAGE_SZ(fs)))
 
 #define SPIFFS_CONFIG_MAGIC             (0x20090315)
 


### PR DESCRIPTION
@pellepl
In Sming framework I am updating Spiffs Config to use SPIFFS_MAGIC.
As discussed in #59 I would like to detect also "short" Filesystems.

In this PR I have made a Proof of Concept for the implementation of that. 
Using a double start & end magic block I can handle the possibility of one erased block.
Based on this I am also planning to implement the possibility to "autosize" the FS.
Giving the Starting address and "maximum size" it would mount the FS with the size, detected by the end magic(s).

Question :  Would you consider accepting these PR's into Spiffs ?

I will not use a local patched Spiffs for the framework so will work out another solution id not incuded here.
In the PR I defined the SPIFFS_MAGIC_START & END but do not know whether this is a valid definiton.
I did not fully test and cleared code of this PR. Will be done when you say OK.   