### PR TITLE
Use const pointer in write functions

### DIFF
--- a/src/spiffs.h
+++ b/src/spiffs.h
@@ -440,7 +440,7 @@ s32_t SPIFFS_read(spiffs *fs, spiffs_file fh, void *buf, s32_t len);
  * @param len           how much to write
  * @returns number of bytes written, or -1 if error
  */
-s32_t SPIFFS_write(spiffs *fs, spiffs_file fh, void *buf, s32_t len);
+s32_t SPIFFS_write(spiffs *fs, spiffs_file fh, const void *buf, s32_t len);
 
 /**
  * Moves the read/write file offset. Resulting offset is returned or negative if error.

--- a/src/spiffs_hydrogen.c
+++ b/src/spiffs_hydrogen.c
@@ -411,7 +411,7 @@ s32_t SPIFFS_read(spiffs *fs, spiffs_file fh, void *buf, s32_t len) {
 }
 
 #if !SPIFFS_READ_ONLY
-static s32_t spiffs_hydro_write(spiffs *fs, spiffs_fd *fd, void *buf, u32_t offset, s32_t len) {
+static s32_t spiffs_hydro_write(spiffs *fs, spiffs_fd *fd, const void *buf, u32_t offset, s32_t len) {
   (void)fs;
   s32_t res = SPIFFS_OK;
   s32_t remaining = len;
@@ -434,7 +434,7 @@ static s32_t spiffs_hydro_write(spiffs *fs, spiffs_fd *fd, void *buf, u32_t offs
 }
 #endif // !SPIFFS_READ_ONLY
 
-s32_t SPIFFS_write(spiffs *fs, spiffs_file fh, void *buf, s32_t len) {
+s32_t SPIFFS_write(spiffs *fs, spiffs_file fh, const void *buf, s32_t len) {
 #if SPIFFS_READ_ONLY
   (void)fs; (void)fh; (void)buf; (void)len;
   return SPIFFS_ERR_RO_NOT_IMPL;


### PR DESCRIPTION
The buffer passed to the write function should be const.