### PR TITLE
Fix the casting ...

### DIFF
--- a/src/spiffs_gc.c
+++ b/src/spiffs_gc.c
@@ -255,7 +255,7 @@ s32_t spiffs_gc_find_candidate(
   s32_t *cand_scores = (s32_t *)(fs->work + max_candidates * sizeof(spiffs_block_ix));
 
    // align cand_scores on s32_t boundary
-  cand_scores = (s32_t*)(((ptrdiff_t)cand_scores + sizeof(ptrdiff_t) - 1) & ~(sizeof(ptrdiff_t) - 1));
+  cand_scores = (s32_t*)(((intptr_t)cand_scores + sizeof(intptr_t) - 1) & ~(sizeof(intptr_t) - 1));
 
   *block_candidates = cand_blocks;
 


### PR DESCRIPTION
For some reason, on some 32 bit linux platforms, ptrdiff_t is not the same size as intptr_t. This really should be intptr_t....

This fixes #105 