### PR TITLE
make SPIFFS_write() data parameter const

### DIFF
--- a/src/spiffs.h
+++ b/src/spiffs.h
@@ -81,7 +81,7 @@ struct spiffs_t;
 /* spi read call function type */
 typedef s32_t (*spiffs_read)(struct spiffs_t *fs, u32_t addr, u32_t size, u8_t *dst);
 /* spi write call function type */
-typedef s32_t (*spiffs_write)(struct spiffs_t *fs, u32_t addr, u32_t size, u8_t *src);
+typedef s32_t (*spiffs_write)(struct spiffs_t *fs, u32_t addr, u32_t size, const u8_t *src);
 /* spi erase call function type */
 typedef s32_t (*spiffs_erase)(struct spiffs_t *fs, u32_t addr, u32_t size);
 
@@ -90,7 +90,7 @@ typedef s32_t (*spiffs_erase)(struct spiffs_t *fs, u32_t addr, u32_t size);
 /* spi read call function type */
 typedef s32_t (*spiffs_read)(u32_t addr, u32_t size, u8_t *dst);
 /* spi write call function type */
-typedef s32_t (*spiffs_write)(u32_t addr, u32_t size, u8_t *src);
+typedef s32_t (*spiffs_write)(u32_t addr, u32_t size, const u8_t *src);
 /* spi erase call function type */
 typedef s32_t (*spiffs_erase)(u32_t addr, u32_t size);
 #endif // SPIFFS_HAL_CALLBACK_EXTRA
@@ -459,7 +459,7 @@ s32_t SPIFFS_read(spiffs *fs, spiffs_file fh, void *buf, s32_t len);
  * @param len           how much to write
  * @returns number of bytes written, or -1 if error
  */
-s32_t SPIFFS_write(spiffs *fs, spiffs_file fh, void *buf, s32_t len);
+s32_t SPIFFS_write(spiffs *fs, spiffs_file fh, const void *buf, s32_t len);
 
 /**
  * Moves the read/write file offset. Resulting offset is returned or negative if error.

--- a/src/spiffs_cache.c
+++ b/src/spiffs_cache.c
@@ -183,7 +183,7 @@ s32_t spiffs_phys_wr(
     spiffs_file fh,
     u32_t addr,
     u32_t len,
-    u8_t *src) {
+    const u8_t *src) {
   (void)fh;
   spiffs_page_ix pix = SPIFFS_PADDR_TO_PAGE(fs, addr);
   spiffs_cache *cache = spiffs_get_cache(fs);

--- a/src/spiffs_hydrogen.c
+++ b/src/spiffs_hydrogen.c
@@ -411,22 +411,22 @@ s32_t SPIFFS_read(spiffs *fs, spiffs_file fh, void *buf, s32_t len) {
 }
 
 #if !SPIFFS_READ_ONLY
-static s32_t spiffs_hydro_write(spiffs *fs, spiffs_fd *fd, void *buf, u32_t offset, s32_t len) {
+static s32_t spiffs_hydro_write(spiffs *fs, spiffs_fd *fd, const void *buf, u32_t offset, s32_t len) {
   (void)fs;
   s32_t res = SPIFFS_OK;
   s32_t remaining = len;
   if (fd->size != SPIFFS_UNDEFINED_LEN && offset < fd->size) {
     s32_t m_len = MIN((s32_t)(fd->size - offset), len);
-    res = spiffs_object_modify(fd, offset, (u8_t *)buf, m_len);
+    res = spiffs_object_modify(fd, offset, (const u8_t *)buf, m_len);
     SPIFFS_CHECK_RES(res);
     remaining -= m_len;
-    u8_t *buf_8 = (u8_t *)buf;
+    const u8_t *buf_8 = (const u8_t *)buf;
     buf_8 += m_len;
     buf = buf_8;
     offset += m_len;
   }
   if (remaining > 0) {
-    res = spiffs_object_append(fd, offset, (u8_t *)buf, remaining);
+    res = spiffs_object_append(fd, offset, (const u8_t *)buf, remaining);
     SPIFFS_CHECK_RES(res);
   }
   return len;
@@ -434,7 +434,7 @@ static s32_t spiffs_hydro_write(spiffs *fs, spiffs_fd *fd, void *buf, u32_t offs
 }
 #endif // !SPIFFS_READ_ONLY
 
-s32_t SPIFFS_write(spiffs *fs, spiffs_file fh, void *buf, s32_t len) {
+s32_t SPIFFS_write(spiffs *fs, spiffs_file fh, const void *buf, s32_t len) {
 #if SPIFFS_READ_ONLY
   (void)fs; (void)fh; (void)buf; (void)len;
   return SPIFFS_ERR_RO_NOT_IMPL;

--- a/src/spiffs_nucleus.c
+++ b/src/spiffs_nucleus.c
@@ -73,7 +73,7 @@ s32_t spiffs_phys_wr(
     spiffs *fs,
     u32_t addr,
     u32_t len,
-    u8_t *src) {
+    const u8_t *src) {
   return SPIFFS_HAL_WRITE(fs, addr, len, src);
 }
 
@@ -754,7 +754,7 @@ s32_t spiffs_page_allocate_data(
     spiffs *fs,
     spiffs_obj_id obj_id,
     spiffs_page_header *ph,
-    u8_t *data,
+    const u8_t *data,
     u32_t len,
     u32_t page_offs,
     u8_t finalize,
@@ -1155,7 +1155,7 @@ s32_t spiffs_object_open_by_page(
 #if !SPIFFS_READ_ONLY
 // Append to object
 // keep current object index (header) page in fs->work buffer
-s32_t spiffs_object_append(spiffs_fd *fd, u32_t offset, u8_t *data, u32_t len) {
+s32_t spiffs_object_append(spiffs_fd *fd, u32_t offset, const u8_t *data, u32_t len) {
   spiffs *fs = fd->fs;
   s32_t res = SPIFFS_OK;
   u32_t written = 0;
@@ -1402,7 +1402,7 @@ s32_t spiffs_object_append(spiffs_fd *fd, u32_t offset, u8_t *data, u32_t len) {
 #if !SPIFFS_READ_ONLY
 // Modify object
 // keep current object index (header) page in fs->work buffer
-s32_t spiffs_object_modify(spiffs_fd *fd, u32_t offset, u8_t *data, u32_t len) {
+s32_t spiffs_object_modify(spiffs_fd *fd, u32_t offset, const u8_t *data, u32_t len) {
   spiffs *fs = fd->fs;
   s32_t res = SPIFFS_OK;
   u32_t written = 0;

--- a/src/spiffs_nucleus.h
+++ b/src/spiffs_nucleus.h
@@ -532,7 +532,7 @@ s32_t spiffs_phys_wr(
 #endif
     u32_t addr,
     u32_t len,
-    u8_t *src);
+    const u8_t *src);
 
 s32_t spiffs_phys_cpy(
     spiffs *fs,
@@ -610,7 +610,7 @@ s32_t spiffs_page_allocate_data(
     spiffs *fs,
     spiffs_obj_id obj_id,
     spiffs_page_header *ph,
-    u8_t *data,
+    const u8_t *data,
     u32_t len,
     u32_t page_offs,
     u8_t finalize,
@@ -684,13 +684,13 @@ s32_t spiffs_object_open_by_page(
 s32_t spiffs_object_append(
     spiffs_fd *fd,
     u32_t offset,
-    u8_t *data,
+    const u8_t *data,
     u32_t len);
 
 s32_t spiffs_object_modify(
     spiffs_fd *fd,
     u32_t offset,
-    u8_t *data,
+    const u8_t *data,
     u32_t len);
 
 s32_t spiffs_object_read(

--- a/src/test/test_spiffs.c
+++ b/src/test/test_spiffs.c
@@ -163,7 +163,7 @@ static s32_t _read(spiffs *fs, u32_t addr, u32_t size, u8_t *dst) {
   return 0;
 }
 
-static s32_t _write(spiffs *fs, u32_t addr, u32_t size, u8_t *src) {
+static s32_t _write(spiffs *fs, u32_t addr, u32_t size, const u8_t *src) {
   int i;
   //printf("wr %08x %i\n", addr, size);
   if (log_flash_ops) {


### PR DESCRIPTION
SPIFFS_write() doesn't change the source data, so mark it as const.

This fixes a warning when SPIFFS_write() is used on read-only data (and probably allows some compiler optimizations).

changes `s32_t SPIFFS_write(spiffs *fs, spiffs_file fh, void *buf, s32_t len);` -> `s32_t SPIFFS_write(spiffs *fs, spiffs_file fh, const void *buf, s32_t len);`