### PR TITLE
set file offset when seeking over end

### DIFF
--- a/src/spiffs_hydrogen.c
+++ b/src/spiffs_hydrogen.c
@@ -587,6 +587,7 @@ s32_t SPIFFS_lseek(spiffs *fs, spiffs_file fh, s32_t offs, int whence) {
   }
 
   if ((offs > (s32_t)fd->size) && (SPIFFS_UNDEFINED_LEN != fd->size)) {
+    fd->fdoffset = fd->size;
     res = SPIFFS_ERR_END_OF_OBJECT;
   }
   SPIFFS_API_CHECK_RES_UNLOCK(fs, res);


### PR DESCRIPTION
The proposed change sets the file offset to the file's end when the file size is smaller than the expected seek index. This allows to use seek to put the file location to a certain position or the end.