### PR TITLE
Add optional file metadata

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ compiler:
 
 before_script:
 
-script: make all && make clean && make test && make build-all
+script: make all && make clean && make test && make build-all && make clean test FLAGS=-DSPIFFS_OBJ_META_LEN=8

--- a/src/default/spiffs_config.h
+++ b/src/default/spiffs_config.h
@@ -107,6 +107,13 @@
 #define SPIFFS_OBJ_NAME_LEN             (32)
 #endif
 
+// Maximum length of the metadata associated with an object.
+// Setting to non-zero value enables metadata-related API but also
+// changes the on-disk format, so the change is not backward-compatible.
+#ifndef SPIFFS_OBJ_META_LEN
+#define SPIFFS_OBJ_META_LEN             (0)
+#endif
+
 // Size of buffer allocated on stack used when copying data.
 // Lower value generates more read/writes. No meaning having it bigger
 // than logical page size.

--- a/src/default/spiffs_config.h
+++ b/src/default/spiffs_config.h
@@ -110,6 +110,13 @@
 // Maximum length of the metadata associated with an object.
 // Setting to non-zero value enables metadata-related API but also
 // changes the on-disk format, so the change is not backward-compatible.
+//
+// Do note: the meta length must never exceed
+// logical_page_size - (SPIFFS_OBJ_NAME_LEN + 64)
+//
+// This is derived from following:
+// logical_page_size - (SPIFFS_OBJ_NAME_LEN + sizeof(spiffs_page_header) +
+// spiffs_object_ix_header fields + at least some LUT entries)
 #ifndef SPIFFS_OBJ_META_LEN
 #define SPIFFS_OBJ_META_LEN             (0)
 #endif

--- a/src/spiffs.h
+++ b/src/spiffs.h
@@ -297,6 +297,9 @@ typedef struct {
   spiffs_obj_type type;
   spiffs_page_ix pix;
   u8_t name[SPIFFS_OBJ_NAME_LEN];
+#if SPIFFS_OBJ_META_LEN
+  u8_t meta[SPIFFS_OBJ_META_LEN];
+#endif
 } spiffs_stat;
 
 struct spiffs_dirent {
@@ -305,6 +308,9 @@ struct spiffs_dirent {
   spiffs_obj_type type;
   u32_t size;
   spiffs_page_ix pix;
+#if SPIFFS_OBJ_META_LEN
+  u8_t meta[SPIFFS_OBJ_META_LEN];
+#endif
 };
 
 typedef struct {
@@ -524,6 +530,24 @@ s32_t SPIFFS_close(spiffs *fs, spiffs_file fh);
  * @param newPath       new path of file
  */
 s32_t SPIFFS_rename(spiffs *fs, const char *old, const char *newPath);
+
+#if SPIFFS_OBJ_META_LEN
+/**
+ * Updates file's metadata
+ * @param fs            the file system struct
+ * @param path          path to the file
+ * @param meta          new metadata. must be SPIFFS_OBJ_META_LEN bytes long.
+ */
+s32_t SPIFFS_update_meta(spiffs *fs, const char *name, const void *meta);
+
+/**
+ * Updates file's metadata
+ * @param fs            the file system struct
+ * @param fh            file handle of the file
+ * @param meta          new metadata. must be SPIFFS_OBJ_META_LEN bytes long.
+ */
+s32_t SPIFFS_fupdate_meta(spiffs *fs, spiffs_file fh, const void *meta);
+#endif
 
 /**
  * Returns last error of last file operation.

--- a/src/spiffs_gc.c
+++ b/src/spiffs_gc.c
@@ -575,7 +575,7 @@ s32_t spiffs_gc_clean(spiffs *fs, spiffs_block_ix bix) {
       cur_entry = gc.stored_scan_entry_index; // pop cursor
       if (gc.cur_objix_spix == 0) {
         // store object index header page
-        res = spiffs_object_update_index_hdr(fs, 0, gc.cur_obj_id | SPIFFS_OBJ_ID_IX_FLAG, gc.cur_objix_pix, fs->work, 0, 0, &new_objix_pix);
+        res = spiffs_object_update_index_hdr(fs, 0, gc.cur_obj_id | SPIFFS_OBJ_ID_IX_FLAG, gc.cur_objix_pix, fs->work, 0, 0, 0, &new_objix_pix);
         SPIFFS_GC_DBG("gc_clean: MOVE_DATA store modified objix_hdr page, %04x:%04x\n", new_objix_pix, 0);
         SPIFFS_CHECK_RES(res);
       } else {

--- a/src/spiffs_nucleus.h
+++ b/src/spiffs_nucleus.h
@@ -480,6 +480,10 @@ typedef struct __attribute(( packed ))
   spiffs_obj_type type;
   // name of object
   u8_t name[SPIFFS_OBJ_NAME_LEN];
+#if SPIFFS_OBJ_META_LEN
+  // metadata. not interpreted by SPIFFS in any way.
+  u8_t meta[SPIFFS_OBJ_META_LEN];
+#endif
 } spiffs_page_object_ix_header;
 
 // object index page header
@@ -635,6 +639,7 @@ s32_t spiffs_object_create(
     spiffs *fs,
     spiffs_obj_id obj_id,
     const u8_t name[SPIFFS_OBJ_NAME_LEN],
+    const u8_t meta[SPIFFS_OBJ_META_LEN],
     spiffs_obj_type type,
     spiffs_page_ix *objix_hdr_pix);
 
@@ -645,6 +650,7 @@ s32_t spiffs_object_update_index_hdr(
     spiffs_page_ix objix_hdr_pix,
     u8_t *new_objix_hdr_data,
     const u8_t name[SPIFFS_OBJ_NAME_LEN],
+    const u8_t meta[SPIFFS_OBJ_META_LEN],
     u32_t size,
     spiffs_page_ix *new_pix);
 

--- a/src/test/test_bugreports.c
+++ b/src/test/test_bugreports.c
@@ -194,7 +194,6 @@ TEST(nodemcu_309) {
     fd = SPIFFS_open(FS, fname, SPIFFS_RDWR | SPIFFS_CREAT | SPIFFS_TRUNC | SPIFFS_DIRECT, 0);
     TEST_CHECK(fd > 0);
     int i;
-    spiffs_stat s;
     res = SPIFFS_OK;
     u8_t err = 0;
     for (i = 1; i <= 1280; i++) {
@@ -247,7 +246,6 @@ TEST(robert) {
   sprintf(fname, "test.txt");
   fd = SPIFFS_open(FS, fname, SPIFFS_RDWR | SPIFFS_CREAT | SPIFFS_TRUNC, 0);
   TEST_CHECK(fd > 0);
-  int i;
   res = SPIFFS_OK;
   char buf[500];
   memset(buf, 0xaa, 500);
@@ -542,8 +540,6 @@ TEST(spiffs_dup_file_74) {
 
 TEST(temporal_fd_cache) {
   fs_reset_specific(0, 0, 1024*1024, 4096, 2*4096, 256);
-  spiffs_file fd;
-  int res;
   (FS)->fd_count = 4;
 
   char *fcss = "blaha.css";
@@ -574,8 +570,6 @@ TEST(temporal_fd_cache) {
 
   int run = 0;
   do {
-    u8_t buf[256];
-
     // open & read an html
     int dice = rand() % 100;
     int probability = 0;

--- a/src/test/test_hydrogen.c
+++ b/src/test/test_hydrogen.c
@@ -189,6 +189,12 @@ TEST(bad_fd)
   res = SPIFFS_write(FS, fd, 0, 0);
   TEST_CHECK(res < 0);
   TEST_CHECK(SPIFFS_errno(FS) == SPIFFS_ERR_BAD_DESCRIPTOR);
+#if SPIFFS_OBJ_META_LEN
+  u8_t new_meta[SPIFFS_OBJ_META_LEN] = {0};
+  res = SPIFFS_fupdate_meta(FS, fd, new_meta);
+  TEST_CHECK(res < 0);
+  TEST_CHECK(SPIFFS_errno(FS) == SPIFFS_ERR_BAD_DESCRIPTOR);
+#endif
   return TEST_RES_OK;
 }
 TEST_END
@@ -218,6 +224,12 @@ TEST(closed_fd)
   res = SPIFFS_write(FS, fd, 0, 0);
   TEST_CHECK(res < 0);
   TEST_CHECK(SPIFFS_errno(FS) == SPIFFS_ERR_FILE_CLOSED);
+#if SPIFFS_OBJ_META_LEN
+  u8_t new_meta[SPIFFS_OBJ_META_LEN] = {0};
+  res = SPIFFS_fupdate_meta(FS, fd, new_meta);
+  TEST_CHECK(res < 0);
+  TEST_CHECK(SPIFFS_errno(FS) == SPIFFS_ERR_FILE_CLOSED);
+#endif
   return TEST_RES_OK;
 }
 TEST_END
@@ -351,8 +363,6 @@ TEST_END
 #if SPIFFS_FILEHDL_OFFSET
 TEST(open_fh_offs)
 {
-  int res;
-  spiffs_stat s;
   spiffs_file fd1, fd2, fd3;
   fd1 = SPIFFS_open(FS, "1", SPIFFS_CREAT | SPIFFS_EXCL, 0);
   fd2 = SPIFFS_open(FS, "2", SPIFFS_CREAT | SPIFFS_EXCL, 0);
@@ -417,6 +427,11 @@ TEST(list_dir)
         break;
       }
     }
+#if SPIFFS_OBJ_META_LEN
+    for (i = 0; i < SPIFFS_OBJ_META_LEN; i++) {
+      TEST_CHECK_EQ(pe->meta[i], 0xff);
+    }
+#endif
   }
   SPIFFS_closedir(&d);
 
@@ -727,6 +742,53 @@ TEST(rename) {
   return TEST_RES_OK;
 } TEST_END
 
+#if SPIFFS_OBJ_META_LEN
+TEST(update_meta) {
+  s32_t i, res, fd;
+  spiffs_stat s;
+  u8_t new_meta[SPIFFS_OBJ_META_LEN], new_meta2[SPIFFS_OBJ_META_LEN];
+
+  res = test_create_file("foo");
+  TEST_CHECK(res >= 0);
+
+  for (i = 0; i < SPIFFS_OBJ_META_LEN; i++) {
+    new_meta[i] = 0xaa;
+  }
+  res = SPIFFS_update_meta(FS, "foo", new_meta);
+  TEST_CHECK(res >= 0);
+
+  res = SPIFFS_stat(FS, "foo", &s);
+  TEST_CHECK(res >= 0);
+  TEST_CHECK_EQ(memcmp(s.meta, new_meta, SPIFFS_OBJ_META_LEN), 0);
+
+  for (i = 0; i < SPIFFS_OBJ_META_LEN; i++) {
+    new_meta2[i] = 0xbb;
+  }
+
+  fd = SPIFFS_open(FS, "foo", SPIFFS_RDONLY, 0);
+  TEST_CHECK(fd >= 0);
+  res = SPIFFS_fupdate_meta(FS, fd, new_meta2);
+  TEST_CHECK(res < 0);
+  TEST_CHECK(SPIFFS_errno(FS) == SPIFFS_ERR_NOT_WRITABLE);
+  SPIFFS_close(FS, fd);
+
+  res = SPIFFS_stat(FS, "foo", &s);
+  TEST_CHECK(res >= 0);
+  TEST_CHECK_EQ(memcmp(s.meta, new_meta, SPIFFS_OBJ_META_LEN), 0);
+
+  fd = SPIFFS_open(FS, "foo", SPIFFS_RDWR, 0);
+  TEST_CHECK(fd >= 0);
+  res = SPIFFS_fupdate_meta(FS, fd, new_meta2);
+  TEST_CHECK_EQ(res, 0);
+  SPIFFS_close(FS, fd);
+
+  res = SPIFFS_stat(FS, "foo", &s);
+  TEST_CHECK(res >= 0);
+  TEST_CHECK_EQ(memcmp(s.meta, new_meta2, SPIFFS_OBJ_META_LEN), 0);
+
+  return TEST_RES_OK;
+} TEST_END
+#endif
 
 TEST(remove_single_by_path)
 {
@@ -1301,7 +1363,6 @@ TEST(lseek_simple_modification) {
   int res;
   spiffs_file fd;
   char *fname = "seekfile";
-  int i;
   int len = 4096;
   fd = SPIFFS_open(FS, fname, SPIFFS_TRUNC | SPIFFS_CREAT | SPIFFS_RDWR, 0);
   TEST_CHECK(fd > 0);
@@ -1341,7 +1402,6 @@ TEST(lseek_modification_append) {
   int res;
   spiffs_file fd;
   char *fname = "seekfile";
-  int i;
   int len = 4096;
   fd = SPIFFS_open(FS, fname, SPIFFS_TRUNC | SPIFFS_CREAT | SPIFFS_RDWR, 0);
   TEST_CHECK(fd > 0);
@@ -2022,7 +2082,7 @@ TEST(ix_map_remap)
 {
   // create a file, 10 data pages long
   s32_t res;
-  spiffs_file fd1, fd2;
+  spiffs_file fd1;
   fd1 = SPIFFS_open(FS, "1", SPIFFS_O_CREAT | SPIFFS_O_WRONLY, 0);
   TEST_CHECK_GT(fd1, 0);
 
@@ -2128,7 +2188,7 @@ TEST(ix_map_partial)
 {
   // create a file, 10 data pages long
   s32_t res;
-  spiffs_file fd, fd2;
+  spiffs_file fd;
   fd = SPIFFS_open(FS, "1", SPIFFS_O_CREAT | SPIFFS_O_WRONLY, 0);
   TEST_CHECK_GT(fd, 0);
 
@@ -2160,7 +2220,6 @@ TEST(ix_map_partial)
   const int entries = SPIFFS_bytes_to_ix_map_entries(FS, size/2);
   spiffs_ix_map map;
   spiffs_page_ix ixbuf[entries];
-  spiffs_page_ix ixbuf_ref[entries];
 
   printf("map 0-50%%\n");
   res = SPIFFS_ix_map(FS, fd, &map, 0, size/2, ixbuf);
@@ -2324,6 +2383,9 @@ SUITE_TESTS(hydrogen_tests)
   ADD_TEST(user_callback_gc)
   ADD_TEST(name_too_long)
   ADD_TEST(rename)
+#if SPIFFS_OBJ_META_LEN
+  ADD_TEST(update_meta)
+#endif
   ADD_TEST(remove_single_by_path)
   ADD_TEST(remove_single_by_fd)
   ADD_TEST(write_cache)

--- a/src/test/test_spiffs.c
+++ b/src/test/test_spiffs.c
@@ -342,7 +342,7 @@ void dump_flash_access_stats() {
 }
 
 
-static u32_t old_perc = 999;
+// static u32_t old_perc = 999;
 static void spiffs_check_cb_f(spiffs *fs, spiffs_check_type type, spiffs_check_report report,
     u32_t arg1, u32_t arg2) {
 /*  if (report == SPIFFS_CHECK_PROGRESS && old_perc != arg1) {
@@ -593,7 +593,6 @@ void real_assert(int c, const char *n, const char *file, int l) {
 }
 
 int read_and_verify(char *name) {
-  s32_t res;
   int fd = SPIFFS_open(&__fs, name, SPIFFS_RDONLY, 0);
   if (fd < 0) {
     printf("  read_and_verify: could not open file %s\n", name);
@@ -693,6 +692,14 @@ int test_create_file(char *name) {
   CHECK_RES(res);
   CHECK(strcmp((char*)s.name, name) == 0);
   CHECK(s.size == 0);
+#if SPIFFS_OBJ_META_LEN
+  {
+    int i;
+    for (i = 0; i < SPIFFS_OBJ_META_LEN; i++) {
+      CHECK(s.meta[i] == 0xff);
+    }
+  }
+#endif
   SPIFFS_close(FS, fd);
   return 0;
 }
@@ -707,7 +714,7 @@ int test_create_and_write_file(char *name, int size, int chunk_size) {
   }
   CHECK(res >= 0);
   fd = SPIFFS_open(FS, name, SPIFFS_APPEND | SPIFFS_RDWR, 0);
-  if (res < 0) {
+  if (fd < 0) {
     printf(" failed open, %i\n",res);
   }
   CHECK(fd >= 0);


### PR DESCRIPTION
Metadata is stored in the file index structure and is opaque to SPIFFS.
It allows user to associate additional information with a file.

Fixes pellepl/spiffs#127