### PR TITLE
when SPIFFS_OBJ_META_LEN = 0, it can cause some compile error.

### DIFF
--- a/src/spiffs_nucleus.c
+++ b/src/spiffs_nucleus.c
@@ -907,8 +907,8 @@ s32_t spiffs_page_delete(
 s32_t spiffs_object_create(
     spiffs *fs,
     spiffs_obj_id obj_id,
-    const u8_t name[SPIFFS_OBJ_NAME_LEN],
-    const u8_t meta[SPIFFS_OBJ_META_LEN],
+    const u8_t name[],
+    const u8_t meta[],
     spiffs_obj_type type,
     spiffs_page_ix *objix_hdr_pix) {
   s32_t res = SPIFFS_OK;
@@ -977,8 +977,8 @@ s32_t spiffs_object_update_index_hdr(
     spiffs_obj_id obj_id,
     spiffs_page_ix objix_hdr_pix,
     u8_t *new_objix_hdr_data,
-    const u8_t name[SPIFFS_OBJ_NAME_LEN],
-    const u8_t meta[SPIFFS_OBJ_META_LEN],
+    const u8_t name[],
+    const u8_t meta[],
     u32_t size,
     spiffs_page_ix *new_pix) {
   s32_t res = SPIFFS_OK;

--- a/src/spiffs_nucleus.h
+++ b/src/spiffs_nucleus.h
@@ -638,8 +638,8 @@ s32_t spiffs_page_delete(
 s32_t spiffs_object_create(
     spiffs *fs,
     spiffs_obj_id obj_id,
-    const u8_t name[SPIFFS_OBJ_NAME_LEN],
-    const u8_t meta[SPIFFS_OBJ_META_LEN],
+    const u8_t name[],
+    const u8_t meta[],
     spiffs_obj_type type,
     spiffs_page_ix *objix_hdr_pix);
 
@@ -649,8 +649,8 @@ s32_t spiffs_object_update_index_hdr(
     spiffs_obj_id obj_id,
     spiffs_page_ix objix_hdr_pix,
     u8_t *new_objix_hdr_data,
-    const u8_t name[SPIFFS_OBJ_NAME_LEN],
-    const u8_t meta[SPIFFS_OBJ_META_LEN],
+    const u8_t name[],
+    const u8_t meta[],
     u32_t size,
     spiffs_page_ix *new_pix);
 


### PR DESCRIPTION
Error[Pe094]: the size of an array must be greater than zero 
\spiffs\spiffs_nucleus.c 981 
