### PR TITLE
src/spiffs_nucleus: remove useless +1/-1 and force comparison to unsigned

### DIFF
--- a/src/spiffs_nucleus.c
+++ b/src/spiffs_nucleus.c
@@ -713,8 +713,8 @@ s32_t spiffs_populate_ix_map(spiffs *fs, spiffs_fd *fd, u32_t vec_entry_start, u
   s32_t res;
   spiffs_ix_map *map = fd->ix_map;
   spiffs_ix_map_populate_state state;
-  vec_entry_start = MIN((map->end_spix - map->start_spix + 1) - 1, (s32_t)vec_entry_start);
-  vec_entry_end = MAX((map->end_spix - map->start_spix + 1) - 1, (s32_t)vec_entry_end);
+  vec_entry_start = MIN((u32_t)(map->end_spix - map->start_spix), vec_entry_start);
+  vec_entry_end = MAX((u32_t)(map->end_spix - map->start_spix), vec_entry_end);
   if (vec_entry_start > vec_entry_end) {
     return SPIFFS_ERR_IX_MAP_BAD_RANGE;
   }


### PR DESCRIPTION
In both lines changed:

* An integer quantity is incremented then decremented, which amounts to a no-op (and may cause the compiler to consider the whole expression as undefined behavior due to the possibility of overflow): remove both increment and decrement.

* the right side of a comparison (hidden within the `MIN` or `MAX` macro) is cast from unsigned to signed probably in order to please  the compiler when the left side is a `u16_t` (and thus may get promoted to a bigger-sized signed int on 32- or 64-bit architectures). Remove the right side cast and cast the left side to `u32_t` (which is the expected type of the `MIN` or `MAX` result) instead, which pleases the compiler whatever the size of the left side.

Note: `make test` passes all 82 tests, and `make build-all` succeeds.