### PR TITLE
faulty intialization in spiffs_create_object

### DIFF
--- a/build/run_valgrind.sh
+++ b/build/run_valgrind.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+valgrind  --show-reachable=yes --track-origins=yes --leak-check=full ./linux_spiffs_test &> valgrind_output.txt
+

--- a/src/spiffs_gc.c
+++ b/src/spiffs_gc.c
@@ -107,9 +107,11 @@ s32_t spiffs_gc_quick(
 // Checks if garbage collecting is necessary. If so a candidate block is found,
 // cleansed and erased
 s32_t spiffs_gc_check(
-    spiffs *fs,
-    u32_t len) {
-  s32_t res;
+                      spiffs *fs,
+                      u32_t   len
+					 )
+{
+  s32_t res = SPIFFS_OK;
   s32_t free_pages =
       (SPIFFS_PAGES_PER_BLOCK(fs) - SPIFFS_OBJ_LOOKUP_PAGES(fs)) * (fs->block_count-2)
       - fs->stats_p_allocated - fs->stats_p_deleted;

--- a/src/test/test_bugreports.c
+++ b/src/test/test_bugreports.c
@@ -628,7 +628,7 @@ static int run_fuzz_test(FILE *f, int maxfds, int debuglog) {
 
   for (i = 0; i < 8; i++) {
     char buff[128];
-    sprintf(buff, "%dfile%d.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxasdasdasdadxxxxxxxxxxxxxxxxxxx", i, i);
+    snprintf(buff, sizeof(buff), "%dfile%d.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxasdasdasdadxxxxxxxxxxxxxxxxxxx", i, i);
     buff[9 + 2 * i] = 0;
     filename[i] = strdup(buff);
   }

--- a/src/test/test_spiffs.c
+++ b/src/test/test_spiffs.c
@@ -113,7 +113,7 @@ static int mkpath(const char *path, mode_t mode) {
 //
 //
 char *make_test_fname(const char *name) {
-  sprintf(_path, "%s/%s", TEST_PATH, name);
+  snprintf(_path, sizeof(_path), "%s/%s", TEST_PATH, name);
   return _path;
 }
 
@@ -132,7 +132,7 @@ void clear_test_path() {
   if (dp != NULL) {
     while ((ep = readdir(dp))) {
       if (ep->d_name[0] != '.') {
-        sprintf(_path, "%s/%s", TEST_PATH, ep->d_name);
+        snprintf(_path, sizeof(_path), "%s/%s", TEST_PATH, ep->d_name);
         remove(_path);
       }
     }


### PR DESCRIPTION
the pullrequest adds a simple shell script to run valgrind :-)
It also fixes:
==25336== Conditional jump or move depends on uninitialised value(s)
==25336==    at 0x41220B: _write (test_spiffs.c:208)
==25336==    by 0x40E993: spiffs_phys_wr (spiffs_cache.c:215)
==25336==    by 0x405622: spiffs_object_append (spiffs_nucleus.c:1436)
==25336==    by 0x40B141: spiffs_hydro_write (spiffs_hydrogen.c:450)
==25336==    by 0x40B809: SPIFFS_write (spiffs_hydrogen.c:587)
==25336==    by 0x41402A: test_create_and_write_file (test_spiffs.c:779)
==25336==    by 0x415A8E: __test_lu_check1 (test_check.c:58)
==25336==    by 0x428D4F: run_tests (testrunner.c:192)
==25336==    by 0x411D08: main (main.c:9)
Which may cause sideeffects for various users ....
My memory overruns seems to be fixe - here I need just more testing to be shure.
Happy testing!