### PR TITLE
Add checks for SIPFFS_CACHE before any use of SPIFFS_CACHE_WR and SPIFFS_CACHE_STATS

### DIFF
--- a/src/spiffs_cache.c
+++ b/src/spiffs_cache.c
@@ -43,7 +43,7 @@ static s32_t spiffs_cache_page_free(spiffs *fs, int ix, u8_t write_back) {
       res = SPIFFS_HAL_WRITE(fs, SPIFFS_PAGE_TO_PADDR(fs, cp->pix), SPIFFS_CFG_LOG_PAGE_SZ(fs), mem);
     }
 
-#if SPIFFS_CACHE_WR
+#if SPIFFS_CACHE && SPIFFS_CACHE_WR
     if (cp->flags & SPIFFS_CACHE_FLAG_TYPE_WR) {
       SPIFFS_CACHE_DBG("CACHE_FREE: free cache page "_SPIPRIi" objid "_SPIPRIid"\n", ix, cp->obj_id);
     } else
@@ -134,7 +134,7 @@ s32_t spiffs_phys_rd(
   cache->last_access++;
   if (cp) {
     // we've already got one, you see
-#if SPIFFS_CACHE_STATS
+#if SPIFFS_CACHE && SPIFFS_CACHE_STATS
     fs->cache_hits++;
 #endif
     cp->last_access = cache->last_access;
@@ -145,7 +145,7 @@ s32_t spiffs_phys_rd(
       // for second layer lookup functions, we do not cache in order to prevent shredding
       return SPIFFS_HAL_READ(fs, addr, len, dst);
     }
-#if SPIFFS_CACHE_STATS
+#if SPIFFS_CACHE && SPIFFS_CACHE_STATS
     fs->cache_misses++;
 #endif
     // this operation will always free one cache page (unless all already free),
@@ -222,7 +222,7 @@ s32_t spiffs_phys_wr(
   }
 }
 
-#if SPIFFS_CACHE_WR
+#if SPIFFS_CACHE && SPIFFS_CACHE_WR
 // returns the cache page that this fd refers, or null if no cache page
 spiffs_cache_page *spiffs_cache_page_get_by_fd(spiffs *fs, spiffs_fd *fd) {
   spiffs_cache *cache = spiffs_get_cache(fs);

--- a/src/spiffs_hydrogen.c
+++ b/src/spiffs_hydrogen.c
@@ -390,7 +390,7 @@ static s32_t spiffs_hydro_read(spiffs *fs, spiffs_file fh, void *buf, s32_t len)
     SPIFFS_API_CHECK_RES_UNLOCK(fs, res);
   }
 
-#if SPIFFS_CACHE_WR
+#if SPIFFS_CACHE && SPIFFS_CACHE_WR
   spiffs_fflush_cache(fs, fh);
 #endif
 
@@ -483,7 +483,7 @@ s32_t SPIFFS_write(spiffs *fs, spiffs_file fh, void *buf, s32_t len) {
   }
   offset = fd->fdoffset;
 
-#if SPIFFS_CACHE_WR
+#if SPIFFS_CACHE && SPIFFS_CACHE_WR
   if (fd->cache_page == 0) {
     // see if object id is associated with cache already
     fd->cache_page = spiffs_cache_page_get_by_fd(fs, fd);
@@ -495,14 +495,14 @@ s32_t SPIFFS_write(spiffs *fs, spiffs_file fh, void *buf, s32_t len) {
     } else {
       offset = fd->size;
     }
-#if SPIFFS_CACHE_WR
+#if SPIFFS_CACHE && SPIFFS_CACHE_WR
     if (fd->cache_page) {
       offset = MAX(offset, fd->cache_page->offset + fd->cache_page->size);
     }
 #endif
   }
 
-#if SPIFFS_CACHE_WR
+#if SPIFFS_CACHE && SPIFFS_CACHE_WR
   if ((fd->flags & SPIFFS_O_DIRECT) == 0) {
     if (len < (s32_t)SPIFFS_CFG_LOG_PAGE_SZ(fs)) {
       // small write, try to cache it
@@ -606,7 +606,7 @@ s32_t SPIFFS_lseek(spiffs *fs, spiffs_file fh, s32_t offs, int whence) {
   res = spiffs_fd_get(fs, fh, &fd);
   SPIFFS_API_CHECK_RES_UNLOCK(fs, res);
 
-#if SPIFFS_CACHE_WR
+#if SPIFFS_CACHE && SPIFFS_CACHE_WR
   spiffs_fflush_cache(fs, fh);
 #endif
 
@@ -710,7 +710,7 @@ s32_t SPIFFS_fremove(spiffs *fs, spiffs_file fh) {
     SPIFFS_API_CHECK_RES_UNLOCK(fs, res);
   }
 
-#if SPIFFS_CACHE_WR
+#if SPIFFS_CACHE && SPIFFS_CACHE_WR
   spiffs_cache_fd_release(fs, fd->cache_page);
 #endif
 
@@ -785,7 +785,7 @@ s32_t SPIFFS_fstat(spiffs *fs, spiffs_file fh, spiffs_stat *s) {
   res = spiffs_fd_get(fs, fh, &fd);
   SPIFFS_API_CHECK_RES_UNLOCK(fs, res);
 
-#if SPIFFS_CACHE_WR
+#if SPIFFS_CACHE && SPIFFS_CACHE_WR
   spiffs_fflush_cache(fs, fh);
 #endif
 
@@ -803,7 +803,7 @@ static s32_t spiffs_fflush_cache(spiffs *fs, spiffs_file fh) {
   (void)fs;
   (void)fh;
   s32_t res = SPIFFS_OK;
-#if !SPIFFS_READ_ONLY && SPIFFS_CACHE_WR
+#if !SPIFFS_READ_ONLY && SPIFFS_CACHE && SPIFFS_CACHE_WR
 
   spiffs_fd *fd;
   res = spiffs_fd_get(fs, fh, &fd);
@@ -838,7 +838,7 @@ s32_t SPIFFS_fflush(spiffs *fs, spiffs_file fh) {
   SPIFFS_API_CHECK_CFG(fs);
   SPIFFS_API_CHECK_MOUNT(fs);
   s32_t res = SPIFFS_OK;
-#if !SPIFFS_READ_ONLY && SPIFFS_CACHE_WR
+#if !SPIFFS_READ_ONLY && SPIFFS_CACHE && SPIFFS_CACHE_WR
   SPIFFS_LOCK(fs);
   fh = SPIFFS_FH_UNOFFS(fs, fh);
   res = spiffs_fflush_cache(fs, fh);
@@ -1197,7 +1197,7 @@ s32_t SPIFFS_eof(spiffs *fs, spiffs_file fh) {
   res = spiffs_fd_get(fs, fh, &fd);
   SPIFFS_API_CHECK_RES_UNLOCK(fs, res);
 
-#if SPIFFS_CACHE_WR
+#if SPIFFS_CACHE && SPIFFS_CACHE_WR
   res = spiffs_fflush_cache(fs, fh);
   SPIFFS_API_CHECK_RES_UNLOCK(fs, res);
 #endif
@@ -1221,7 +1221,7 @@ s32_t SPIFFS_tell(spiffs *fs, spiffs_file fh) {
   res = spiffs_fd_get(fs, fh, &fd);
   SPIFFS_API_CHECK_RES_UNLOCK(fs, res);
 
-#if SPIFFS_CACHE_WR
+#if SPIFFS_CACHE && SPIFFS_CACHE_WR
   res = spiffs_fflush_cache(fs, fh);
   SPIFFS_API_CHECK_RES_UNLOCK(fs, res);
 #endif

--- a/src/spiffs_nucleus.c
+++ b/src/spiffs_nucleus.c
@@ -1073,7 +1073,7 @@ void spiffs_cb_object_event(
           // update size and offsets for fds to this file
           cur_fd->size = new_size;
           u32_t act_new_size = new_size == SPIFFS_UNDEFINED_LEN ? 0 : new_size;
-#if SPIFFS_CACHE_WR
+#if SPIFFS_CACHE && SPIFFS_CACHE_WR
           if (act_new_size > 0 && cur_fd->cache_page) {
             act_new_size = MAX(act_new_size, cur_fd->cache_page->offset + cur_fd->cache_page->size);
           }
@@ -1084,7 +1084,7 @@ void spiffs_cb_object_event(
           if (cur_fd->fdoffset > act_new_size) {
             cur_fd->fdoffset = act_new_size;
           }
-#if SPIFFS_CACHE_WR
+#if SPIFFS_CACHE && SPIFFS_CACHE_WR
           if (cur_fd->cache_page && cur_fd->cache_page->offset > act_new_size+1) {
             SPIFFS_CACHE_DBG("CACHE_DROP: file trunced, dropping cache page "_SPIPRIi", no writeback\n", cur_fd->cache_page->ix);
             spiffs_cache_fd_release(fs, cur_fd->cache_page);
@@ -1093,7 +1093,7 @@ void spiffs_cb_object_event(
         }
       } else {
         // removing file
-#if SPIFFS_CACHE_WR
+#if SPIFFS_CACHE && SPIFFS_CACHE_WR
         if (cur_fd->file_nbr && cur_fd->cache_page) {
           SPIFFS_CACHE_DBG("CACHE_DROP: file deleted, dropping cache page "_SPIPRIi", no writeback\n", cur_fd->cache_page->ix);
           spiffs_cache_fd_release(fs, cur_fd->cache_page);

--- a/src/spiffs_nucleus.h
+++ b/src/spiffs_nucleus.h
@@ -411,7 +411,7 @@ typedef struct {
       // read cache page index
       spiffs_page_ix pix;
     };
-#if SPIFFS_CACHE_WR
+#if SPIFFS_CACHE && SPIFFS_CACHE_WR
     // type write cache
     struct {
       // write cache
@@ -459,7 +459,7 @@ typedef struct {
   u32_t fdoffset;
   // fd flags
   spiffs_flags flags;
-#if SPIFFS_CACHE_WR
+#if SPIFFS_CACHE && SPIFFS_CACHE_WR
   spiffs_cache_page *cache_page;
 #endif
 #if SPIFFS_TEMPORAL_FD_CACHE


### PR DESCRIPTION
I had to compile code with SPIFFS_CACHE 0 and there were a lot of checks for SPIFFS_CACHE_WR that did not first check if SPIFFS_CACHE was turned on.