### PR TITLE
Add secure erase via zeroing page contents on deletion

### DIFF
--- a/src/default/spiffs_config.h
+++ b/src/default/spiffs_config.h
@@ -350,6 +350,10 @@
 #endif
 #endif
 
+#ifndef SPIFFS_SECURE_ERASE
+#define SPIFFS_SECURE_ERASE 0
+#endif
+
 // Types depending on configuration such as the amount of flash bytes
 // given to spiffs file system in total (spiffs_file_system_size),
 // the logical block size (log_block_size), and the logical page size

--- a/src/spiffs_nucleus.c
+++ b/src/spiffs_nucleus.c
@@ -889,6 +889,16 @@ s32_t spiffs_page_delete(
   fs->stats_p_deleted++;
   fs->stats_p_allocated--;
 
+#if SPIFFS_SECURE_ERASE
+  // Secure erase
+  unsigned char data[SPIFFS_CFG_LOG_PAGE_SZ(fs) - sizeof(spiffs_page_header)];
+  bzero(data, sizeof(data));
+  res = _spiffs_wr(fs,  SPIFFS_OP_T_OBJ_DA | SPIFFS_OP_C_DELE,
+      0,
+      SPIFFS_PAGE_TO_PADDR(fs, pix) + sizeof(spiffs_page_header), sizeof(data), data);
+  SPIFFS_CHECK_RES(res);
+#endif
+
   // mark deleted in source page
   u8_t flags = 0xff;
 #if SPIFFS_NO_BLIND_WRITES


### PR DESCRIPTION
For some applications (like storing keys and sensitive data) secure erase is required option