### PR TITLE
Add ability to override the sizes of spiffs internal data types

### DIFF
--- a/src/default/spiffs_config.h
+++ b/src/default/spiffs_config.h
@@ -359,6 +359,7 @@
 // the logical block size (log_block_size), and the logical page size
 // (log_page_size)
 
+#ifndef SPIFFS_TYPES_OVERRIDE
 // Block index type. Make sure the size of this type can hold
 // the highest number of all blocks - i.e. spiffs_file_system_size / log_block_size
 typedef u16_t spiffs_block_ix;
@@ -373,5 +374,6 @@ typedef u16_t spiffs_obj_id;
 // hold the largest possible span index on the system -
 // i.e. (spiffs_file_system_size / log_page_size) - 1
 typedef u16_t spiffs_span_ix;
+#endif
 
 #endif /* SPIFFS_CONFIG_H_ */

--- a/src/default/spiffs_config.h
+++ b/src/default/spiffs_config.h
@@ -358,6 +358,10 @@
 // given to spiffs file system in total (spiffs_file_system_size),
 // the logical block size (log_block_size), and the logical page size
 // (log_page_size)
+//
+// Set SPIFFS_TYPES_OVERRIDE if you wish to have your own
+// definitions for these types (for example, if you want them
+// to be u32_t)
 
 #ifndef SPIFFS_TYPES_OVERRIDE
 // Block index type. Make sure the size of this type can hold


### PR DESCRIPTION
For reasons unknown to me, somebody changed the size of some internal spiffs types from 16 to 32 bits (spiffs_block_ix, spiffs_page_ix, spiffs_obj_id, spiffs_span_ix) on our device.

As I was updating our spiffs source to the current head, I followed the model suggested by params_test.h and I pulled out all of our changes to the default spiffs_config.h into a separate file to minimize future merging headaches. Of course, I had to wrap these type changes with an `#ifndef SPIFFS_TYPES_OVERRIDE` block to make the scheme work.