### PR TITLE
Fix possible source of overflow in SPIFFS_check

### DIFF
--- a/src/spiffs_check.c
+++ b/src/spiffs_check.c
@@ -521,7 +521,7 @@ s32_t spiffs_lookup_consistency_check(spiffs *fs, u8_t check_all_objects) {
 // The working memory might not fit all pages so several scans might be needed
 static s32_t spiffs_page_consistency_check_i(spiffs *fs) {
   const u32_t bits = 4;
-  const spiffs_page_ix pages_per_scan = SPIFFS_CFG_LOG_PAGE_SZ(fs) * 8 / bits;
+  const u32_t pages_per_scan = SPIFFS_CFG_LOG_PAGE_SZ(fs) * 8 / bits;
 
   s32_t res = SPIFFS_OK;
   spiffs_page_ix pix_offset = 0;


### PR DESCRIPTION
Hi there,

I was testing a file system configuration with a logical page size of 32 KiB and got the following compiler warning:

```
In file included from spiffs/src/spiffs.h:14:0,
                 from spiffs/src/spiffs_check.c:23:
spiffs/src/spiffs_check.c: In function 'spiffs_page_consistency_check_i':
../shared/spiffs_config.h:223:43: warning: large integer implicitly truncated to unsigned type [-Woverflow]
 #define SPIFFS_CFG_LOG_PAGE_SZ(ignore)    (32 * 1024)
                                           ^
spiffs/src/spiffs_check.c:524:41: note: in expansion of macro 'SPIFFS_CFG_LOG_PAGE_SZ'
   const spiffs_page_ix pages_per_scan = SPIFFS_CFG_LOG_PAGE_SZ(fs) * 8 / bits;
```

My file system is 124 MiB in size, so I chose uint16_t as the type used to store `spiffs_page_ix`, because a `uint16_t` can safely store page indices for the roughly 4,000 pages in the file system. However in the above calculation the value computed for `pages_per_scan` is 65536 which is an overflow of `uint16_t`.

I changed the type of `pages_per_scan` to `u32_t`, which isn't the best solution but should work for the vast majority of configurations!
