### PR TITLE
Fix gcc release warnings

### DIFF
--- a/src/spiffs_hydrogen.c
+++ b/src/spiffs_hydrogen.c
@@ -1443,7 +1443,7 @@ s32_t SPIFFS_vis(spiffs *fs) {
   spiffs_printf("page_alloc:  "_SPIPRIi"\n", fs->stats_p_allocated);
   spiffs_printf("page_delet:  "_SPIPRIi"\n", fs->stats_p_deleted);
   SPIFFS_UNLOCK(fs);
-  u32_t total, used;
+  u32_t total = 0u, used = 0u;
   SPIFFS_info(fs, &total, &used);
   spiffs_printf("used:        "_SPIPRIi" of "_SPIPRIi"\n", used, total);
   return res;

--- a/src/spiffs_nucleus.c
+++ b/src/spiffs_nucleus.c
@@ -954,7 +954,8 @@ s32_t spiffs_object_create(
   oix_hdr.p_hdr.flags = 0xff & ~(SPIFFS_PH_FLAG_FINAL | SPIFFS_PH_FLAG_INDEX | SPIFFS_PH_FLAG_USED);
   oix_hdr.type = type;
   oix_hdr.size = SPIFFS_UNDEFINED_LEN; // keep ones so we can update later without wasting this page
-  strncpy((char*)oix_hdr.name, (const char*)name, SPIFFS_OBJ_NAME_LEN);
+  strncpy((char*)oix_hdr.name, (const char*)name, sizeof(oix_hdr.name) - 1);
+  ((char*)oix_hdr.name)[sizeof(oix_hdr.name) - 1] = '\0';
 #if SPIFFS_OBJ_META_LEN
   if (meta) {
     _SPIFFS_MEMCPY(oix_hdr.meta, meta, SPIFFS_OBJ_META_LEN);


### PR DESCRIPTION
In our projects we have strict set of gcc warnings and we also build Release configuration, thus we had to introduce these commits to make our build pipeline happy.