### PR TITLE
fix SPIFFS_readdir setting errno to SPIFFS_VIS_END at the end of iteration

### DIFF
--- a/src/spiffs_hydrogen.c
+++ b/src/spiffs_hydrogen.c
@@ -1121,6 +1121,8 @@ struct spiffs_dirent *SPIFFS_readdir(spiffs_DIR *d, struct spiffs_dirent *e) {
     d->entry = entry + 1;
     e->obj_id &= ~SPIFFS_OBJ_ID_IX_FLAG;
     ret = e;
+  } else if (res == SPIFFS_VIS_END) {
+    // end of iteration
   } else {
     d->fs->err_code = res;
   }

--- a/src/test/test_hydrogen.c
+++ b/src/test/test_hydrogen.c
@@ -439,6 +439,7 @@ TEST(list_dir)
 #endif
     }
   }
+  TEST_CHECK_EQ(SPIFFS_errno(FS), SPIFFS_OK);
   SPIFFS_closedir(&d);
 
   TEST_CHECK(found == file_cnt);


### PR DESCRIPTION
When iteration finishes, `spiffs_obj_lu_find_entry_visitor` returns
`SPIFFS_VIS_END`. Previously, `SPIFFS_readdir` function used to set
`errno` to this internal error value when readdir reached the end.

Handle this case and add a check into the regression test.

(Original issue: https://github.com/esp-rs/rust/issues/117#issuecomment-1142159661)