### PR TITLE
fix: prevent stack buffer overflow in spiffs_read_dir_v()

### DIFF
--- a/src/spiffs_hydrogen.c
+++ b/src/spiffs_hydrogen.c
@@ -1083,7 +1083,8 @@ static s32_t spiffs_read_dir_v(
           (SPIFFS_PH_FLAG_DELET | SPIFFS_PH_FLAG_IXDELE)) {
     struct spiffs_dirent *e = (struct spiffs_dirent*)user_var_p;
     e->obj_id = obj_id;
-    strcpy((char *)e->name, (char *)objix_hdr.name);
+    strncpy((char *)e->name, (char *)objix_hdr.name, sizeof(e->name) - 1);
+    e->name[sizeof(e->name) - 1] = '\0';
     e->type = objix_hdr.type;
     e->size = objix_hdr.size == SPIFFS_UNDEFINED_LEN ? 0 : objix_hdr.size;
     e->pix = pix;


### PR DESCRIPTION
## Summary

Replace unbounded `strcpy` with `strncpy` + explicit NUL termination in `spiffs_read_dir_v()` (`src/spiffs_hydrogen.c:1086`).

The object index header name field is read directly from raw flash data and may not be NUL-terminated. `strcpy` reads past the end of the stack-allocated `objix_hdr` variable, causing a stack buffer overflow.

This matches the fix already applied to the **write** path in commit 8eb5cd3 (`spiffs_nucleus.c:1018`), which uses `strncpy` + explicit NUL.

## Details

- **Function**: `spiffs_read_dir_v()` in `src/spiffs_hydrogen.c`
- **Root cause**: `objix_hdr.name` (read from flash via `_spiffs_rd()`) may lack a NUL terminator within `SPIFFS_OBJ_NAME_LEN` bytes
- **Impact**: Stack buffer overflow, crash on `SPIFFS_readdir()` with corrupted filesystem
- **Found via**: Coverage-guided fuzzing (libFuzzer + AddressSanitizer)

Fixes #302