### PR TITLE
fix: validate cache page index in spiffs_cache_page_free

### DIFF
--- a/src/spiffs_cache.c
+++ b/src/spiffs_cache.c
@@ -33,6 +33,9 @@ static spiffs_cache_page *spiffs_cache_page_get(spiffs *fs, spiffs_page_ix pix) 
 static s32_t spiffs_cache_page_free(spiffs *fs, int ix, u8_t write_back) {
   s32_t res = SPIFFS_OK;
   spiffs_cache *cache = spiffs_get_cache(fs);
+  if (ix < 0 || ix >= (int)cache->cpage_count) {
+    return SPIFFS_ERR_INTERNAL;
+  }
   spiffs_cache_page *cp = spiffs_get_cache_page_hdr(fs, cache, ix);
   if (cache->cpage_use_map & (1<<ix)) {
     if (write_back &&


### PR DESCRIPTION
## Summary

When a SPIFFS filesystem image is malformed, `cp->ix` can contain an invalid value (e.g. negative). This leads to undefined behavior in the expression `1 << ix` when `ix` is negative or >= 32 (C standard §6.5.7).

This adds a bounds check at the start of `spiffs_cache_page_free()` to return `SPIFFS_ERR_INTERNAL` for out-of-range indices, preventing the UB shift.

## How it was found

Found via fuzzing with [esp-fuzzer](https://github.com/Eun0us/esp-fuzzer) and `-fsanitize=undefined`:

```
src/spiffs_cache.c:54:36: runtime error: shift exponent -2 is negative
    #0 spiffs_cache_page_free src/spiffs_cache.c:54:36
    #1 spiffs_cache_drop_page src/spiffs_cache.c:116:5
```

## Test plan

- [x] Verified fix prevents the UBSan error with malformed filesystem image
- [x] Normal cache operations unaffected (valid indices pass the check)