### PR TITLE
Fix non-NUL-terminated name in spiffs_stat_pix()

### DIFF
--- a/src/spiffs_hydrogen.c
+++ b/src/spiffs_hydrogen.c
@@ -783,7 +783,8 @@ static s32_t spiffs_stat_pix(spiffs *fs, spiffs_page_ix pix, spiffs_file fh, spi
   s->type = objix_hdr.type;
   s->size = objix_hdr.size == SPIFFS_UNDEFINED_LEN ? 0 : objix_hdr.size;
   s->pix = pix;
-  strncpy((char *)s->name, (char *)objix_hdr.name, SPIFFS_OBJ_NAME_LEN);
+  strncpy((char *)s->name, (char *)objix_hdr.name, sizeof(s->name) - 1);
+  s->name[sizeof(s->name) - 1] = '\0';
 #if SPIFFS_OBJ_META_LEN
   _SPIFFS_MEMCPY(s->meta, objix_hdr.meta, SPIFFS_OBJ_META_LEN);
 #endif


### PR DESCRIPTION
## Problem

`spiffs_stat_pix()` (reached via the public `SPIFFS_stat()` / `SPIFFS_fstat()` APIs) copies the object index header's name into `spiffs_stat.name` with:

```c
strncpy((char *)s->name, (char *)objix_hdr.name, SPIFFS_OBJ_NAME_LEN);
```

`objix_hdr.name` is read straight from raw flash (`_spiffs_rd()`), so nothing guarantees it contains a NUL byte within its `SPIFFS_OBJ_NAME_LEN` (32) bytes. Because `strncpy` only pads/terminates when the source is shorter than `n`, a flash-resident name with no embedded NUL (e.g. a corrupted or fuzzed filesystem image) leaves `s->name` with no terminator either.

Under the default build config `name` is the last field of `spiffs_stat`, so any later `strlen()`/`strcmp()`/`printf("%s", ...)` on `stat.name` (as the test suite itself does, e.g. `test_hydrogen.c`, `test_spiffs.c`, `test_bugreports.c`) runs off the end of the struct.

This is the same bug class already fixed twice elsewhere in the codebase for the identical `objix_hdr.name` source field:
- `spiffs_object_update_index_hdr()` in `spiffs_nucleus.c`
- `spiffs_read_dir_v()` in `spiffs_hydrogen.c` (a few hundred lines below this one)

Fixes #262, which independently reported this exact line six years ago.

## Fix

Apply the same pattern already used by both sibling call sites: truncate to `sizeof(...) - 1` and explicitly NUL-terminate the last byte.

```c
strncpy((char *)s->name, (char *)objix_hdr.name, sizeof(s->name) - 1);
s->name[sizeof(s->name) - 1] = '\0';
```

This guarantees termination for the corrupted/fuzzed case while leaving normal short names copied byte-for-byte unchanged.

## Verification

- Compiled `src/spiffs_hydrogen.c` with the change (`gcc -I./src -I./src/default -I./src/test -D_SPIFFS_TEST -Wall -Wextra -c`), clean build (only pre-existing, unrelated `%lx`/`intptr_t` format warnings also present before this change).
- Wrote a standalone test program against the real repo headers (`spiffs.h`, `spiffs_nucleus.h`, `spiffs_config.h`) that:
  - reproduces the bug: a 32-byte `objix_hdr.name` filled with no NUL byte, copied with the old `strncpy(..., SPIFFS_OBJ_NAME_LEN)`, leaves `s->name` with zero NULs in its field.
  - confirms the fix: the same input, copied with the new two-line pattern, always yields a NUL-terminated result (`strlen() == 31`).
  - confirms no regression: a normal short name (`"boot.cfg"`) round-trips byte-for-byte identical to before.