### PR TITLE
Reject oversized paths in SPIFFS_update_meta

### DIFF
--- a/src/spiffs_hydrogen.c
+++ b/src/spiffs_hydrogen.c
@@ -975,6 +975,9 @@ s32_t SPIFFS_update_meta(spiffs *fs, const char *name, const void *meta) {
 #else
   SPIFFS_API_CHECK_CFG(fs);
   SPIFFS_API_CHECK_MOUNT(fs);
+  if (strlen(name) > SPIFFS_OBJ_NAME_LEN - 1) {
+    SPIFFS_API_CHECK_RES(fs, SPIFFS_ERR_NAME_TOO_LONG);
+  }
   SPIFFS_LOCK(fs);
 
   spiffs_page_ix pix, pix_dummy;

--- a/src/test/test_hydrogen.c
+++ b/src/test/test_hydrogen.c
@@ -720,6 +720,12 @@ TEST(name_too_long) {
   TEST_CHECK_LT(SPIFFS_rename(FS, "a", name), SPIFFS_OK);
   TEST_CHECK_EQ(SPIFFS_errno(FS), SPIFFS_ERR_NAME_TOO_LONG);
 
+#if SPIFFS_OBJ_META_LEN
+  u8_t meta[SPIFFS_OBJ_META_LEN] = {0};
+  TEST_CHECK_LT(SPIFFS_update_meta(FS, name, meta), SPIFFS_OK);
+  TEST_CHECK_EQ(SPIFFS_errno(FS), SPIFFS_ERR_NAME_TOO_LONG);
+#endif
+
   return TEST_RES_OK;
 } TEST_END
 


### PR DESCRIPTION
## Summary

- Reject paths longer than SPIFFS_OBJ_NAME_LEN - 1 in SPIFFS_update_meta.
- Extend the existing name_too_long regression when metadata is enabled.

## Problem

SPIFFS_update_meta was the only path-based API that skipped the configured object-name limit. For the first invalid length (32 bytes with the default configuration), the current code scans the object lookup and returns SPIFFS_ERR_NOT_FOUND instead of SPIFFS_ERR_NAME_TOO_LONG.

The check now matches SPIFFS_creat, SPIFFS_open, SPIFFS_remove, SPIFFS_stat, and SPIFFS_rename, and runs before taking the filesystem lock.

## Verification

- Current master with the new regression: failed with -10002 instead of -10036.
- Metadata-enabled full host suite: 92/92 passed.
- Default full host suite: 91/91 passed.
- AddressSanitizer focused runs for name_too_long and update_meta passed.
- git diff --check passed.

No physical flash hardware was used; validation used the repository's emulated-flash host test suite.